### PR TITLE
added possible scenario fix for new lock events

### DIFF
--- a/src/config/events.json
+++ b/src/config/events.json
@@ -6,6 +6,7 @@
     "events": [
       {
         "name": "Transfer",
+        "filter": "Transfer(address,address,uint256)",
         "params": [
           {
             "name": "from",
@@ -33,6 +34,7 @@
     "events": [
       {
         "name": "Transfer",
+        "filter": "Transfer(address,address,uint256)",
         "params": [
           {
             "name": "from",
@@ -60,6 +62,7 @@
     "events": [
       {
         "name": "Transfer",
+        "filter": "Transfer(address,address,uint256)",
         "params": [
           {
             "name": "from",
@@ -80,6 +83,7 @@
       },
       {
         "name": "Locked",
+        "filter": "Locked(uint256)",
         "params": [
           {
             "name": "tokendId",
@@ -90,6 +94,7 @@
       },
       {
         "name": "Unlocked",
+        "filter": "Unlocked(uint256)",
         "params": [
           {
             "name": "tokendId",
@@ -107,6 +112,7 @@
     "events": [
       {
         "name": "Transfer",
+        "filter": "Transfer(address,address,uint256)",
         "params": [
           {
             "name": "from",
@@ -127,6 +133,7 @@
       },
       {
         "name": "Locked",
+        "filter": "Locked(uint256)",
         "params": [
           {
             "name": "tokendId",
@@ -137,6 +144,7 @@
       },
       {
         "name": "Unlocked",
+        "filter": "Unlocked(uint256)",
         "params": [
           {
             "name": "tokendId",

--- a/src/lib/eventScraper.js
+++ b/src/lib/eventScraper.js
@@ -107,7 +107,7 @@ async function processSingleEvent(event, type, argNames) {
   return tx;
 }
 
-async function getEventInfo(eventConfig, eventName) {
+async function getEventInfo(eventConfig, eventName, eventFilter) {
   const { chainId: eventChainId, contractName } = eventConfig;
   let startBlock;
   let lastEvent = await eventManager.latestEvent(contractName, eventName);
@@ -117,12 +117,8 @@ async function getEventInfo(eventConfig, eventName) {
     startBlock = eventConfig.startBlock;
   }
   const provider = providers[eventChainId];
-  const contract = new ethers.Contract(
-    contracts[eventChainId][contractName],
-    abi[contractName],
-    provider
-  );
-  const type = contract.filters[eventName]();
+  const contract = new ethers.Contract(contracts[eventChainId][contractName], abi[contractName], provider);
+  const type = contract.filters[eventFilter]();
   const endBlock = await provider.getBlockNumber();
 
   await getEvents(contract, type, startBlock, endBlock, contractName);
@@ -138,7 +134,7 @@ async function main(opt) {
 
   for (let eventConfig of eventsConfig) {
     for (let event of eventConfig.events) {
-      promises.push(getEventInfo(eventConfig, event.name));
+      promises.push(getEventInfo(eventConfig, event.name, event.filter));
     }
   }
 


### PR DESCRIPTION
In this PR we added a possible scenario to query the new lock event by adding to the eventConfig a filter which contains the full name this allows us the flexibility to change the name for the tables to something like: 
      {
        "name": "NewLockedEvent",
        "filter": "Locked(uint256,bool)",
        "params": [
          {
            "name": "tokendId",
            "type": "bigint",
            "indexed": true
          }
        ]
      }

so we can differentiate the new events and in case in the future that we have similar problems we can create new table for the new events added to contracts using this method.