### PR TITLE
Add end block and restart feature

### DIFF
--- a/src/lib/EventManager.js
+++ b/src/lib/EventManager.js
@@ -50,11 +50,24 @@ class EventManager extends Sql {
     let tablename = utils.nameTable(contractName, eventName);
     const exist = await this.tableExists(tablename);
     if (exist) {
-      event = dbr.select("*").from(tablename).orderBy("block_number", "desc").first();
+      event = dbr
+        .select("*")
+        .from(tablename)
+        .orderBy("block_number", "desc")
+        .first();
     }
     return event;
   }
 
+  async revertTableToBlock(contractName, eventName, blockNumber) {
+    let tablename = utils.nameTable(contractName, eventName);
+    const exist = await this.tableExists(tablename);
+    if (exist) {
+      await dbr.from(tablename).where("block_number", ">", blockNumber).del();
+      return true;
+    }
+    return false;
+  }
   // used in testing
   async getEvent(contractName, eventName, obj) {
     let event = false;

--- a/src/lib/eventScraper.js
+++ b/src/lib/eventScraper.js
@@ -115,10 +115,18 @@ async function getEventInfo(eventConfig, eventName, eventFilter) {
   let startBlock;
   let lastEvent = await eventManager.latestEvent(contractName, eventName);
   if (lastEvent) {
-    startBlock = lastEvent.block_number + 1;
+    startBlock = lastEvent.block_number;
   } else {
     startBlock = eventConfig.startBlock;
   }
+
+  await eventManager.revertTableToBlock(
+    contractName,
+    eventName,
+    startBlock - 11
+  );
+  startBlock = startBlock - 10;
+
   const provider = providers[eventChainId];
   for (let x in events) {
     if (events[x].name === eventName) {


### PR DESCRIPTION
This PR seeks to add two features to the Event Scraper. 
On start it will start from 10 blocks before and Revert the table 10 blocks.
It will not Start the Event Monitor if an "endBlock" is provided in the configuration It will only index up to that block.    
