### PR TITLE
Fixing retrieving recent blocks

### DIFF
--- a/scraper.js
+++ b/scraper.js
@@ -38,8 +38,8 @@ const optionDefinitions = [
     type: Boolean,
   },
   {
-    name: "hours",
-    alias: "o",
+    name: "blocks",
+    alias: "b",
     type: Number,
   },
   {
@@ -81,7 +81,7 @@ Options:
   -c, --contract  The contract to get events from
   -e, --event     The event to retrieve
   -f, --force     Force the retrieve of all the events from deployment time
-  -o, --hours     The number of hours to go back from the last saved event
+  -b, --blocks    It retrieves the events with "fromBlock = latest blocks - blocks" 
   -l, --limit     The number of events to retrieve at any request
 `);
   // eslint-disable-next-line no-process-exit

--- a/src/lib/EventManager.js
+++ b/src/lib/EventManager.js
@@ -68,6 +68,7 @@ class EventManager extends Sql {
           .block_number
       );
     }
+    return false;
   }
 
   async latestEvents(contractName, filter) {


### PR DESCRIPTION
The offset parameter in Moralis API does not work as expected. I added a parameter fromBlock that forces the initial block to me parsed.