### PR TITLE
Truncate table if force

### DIFF
--- a/src/lib/EventManager.js
+++ b/src/lib/EventManager.js
@@ -59,6 +59,11 @@ class EventManager extends Sql {
     }
   }
 
+  async truncateEvents(filter, contractName) {
+    let tableName = utils.nameTable(contractName, filter);
+    await dbw(tableName).truncate();
+  }
+
   async latestBlockByEvent(contractName, filter) {
     let tableName = utils.nameTable(contractName, filter);
     const exist = await this.tableExists(tableName);

--- a/src/lib/eventScraper.js
+++ b/src/lib/eventScraper.js
@@ -64,6 +64,10 @@ async function retrieveHistoricalEvents(params) {
   let logs;
   let topic = ethers.utils.id(params.filterName);
   let fromBlock = await getFromBlock(contractName, filterName);
+  if (options.force) {
+    // we clean the table
+    await eventManager.truncateEvents(filterName, contractName);
+  }
   let offset = 0;
   let limit = options.limit || 500;
   do {


### PR DESCRIPTION
Truncate the table before retrieving the events if the --force option is passed.
For example, to reload all the events from the corePool, we can execute
```
./scraper -fc SyndicateCorePool
```